### PR TITLE
PUBLIC_FOLDER is not defined

### DIFF
--- a/source/scripts/installer.sh
+++ b/source/scripts/installer.sh
@@ -28,6 +28,7 @@ ENGINE_SCRIPT="/var/packages/${SYNOPKG_PKGNAME}/scripts/launcher.sh"
 INSTALL_FILES="${DOWNLOAD_URL}"
 source /etc/profile
 TEMP_FOLDER="`find / -maxdepth 2 -name '@tmp' | head -n 1`"
+PUBLIC_FOLDER="$(synoshare --get public | grep -oP 'Path.+\[\K[^]]+')"
 PRIMARY_VOLUME="/`echo $TEMP_FOLDER | cut -f2 -d'/'`"
 WORLD_BACKUP="${PRIMARY_VOLUME}/public/${DAEMON_USER}world.`date +\"%d-%b\"`.bak"
 


### PR DESCRIPTION
If wget fails there is a bug with getting jar file from PUBLIC_FOLDER, cause this environment variable is not defined.
Based on solution https://github.com/openhab/openhab-syno-spk/blob/master/scripts/installer.sh we can initialize it.